### PR TITLE
Mark connections in pool as closed to prevent reuse

### DIFF
--- a/sqlalchemy_exasol/pyodbc.py
+++ b/sqlalchemy_exasol/pyodbc.py
@@ -103,10 +103,14 @@ class EXADialect_pyodbc(PyODBCConnector, EXADialect):
         return [[";".join(connectors)], connect_args]
 
     def is_disconnect(self, e, connection, cursor):
-        messages = [
-            "[HY000] [EXASOL][EXASolution driver]Socket closed by peer.",
-            "[40004] [EXASOL][EXASolution driver]Connection lost."
-            ]
-        return any(msg in str(e) for msg in messages)
+        if isinstance(e, self.dbapi.Error):
+            error_codes = [
+                    '40004', # Connection lost.
+                    '40009', # Connection lost after internal server error.
+                    '40018', # Connection lost after system running out of memory.
+                    '40020', # Connection lost after system running out of memory.
+                    ]
+            return e.args[0] in error_codes
+        return super(EXADialect_pyodbc, self).is_disconnect(e, connection, cursor)
 
 dialect = EXADialect_pyodbc


### PR DESCRIPTION
Needs further discussion

Example Script 

``` python
from sqlalchemy import *
engine = create_engine("exa+pyodbc://", pool_size=1)
con = engine.connect()
print con.execute("select 1").fetchall()
con.close()
# in exaplusgui
# select * from exa_all_sessions;
# kill session XXXX;
raw_input("Kill session in exaplus and Press button to continue")
con = engine.connect()
try:
    print con.execute("select 1").fetchall()
except Exception as e:
    #[40004] [EXASOL][EXASolution driver]Connection lost.
    print e
finally:
    con.close()
con = engine.connect()
print con.execute("select 1").fetchall()
#[HY000] [EXASOL][EXASolution driver]Socket closed by peer
```
