### PR TITLE
Fix tests failing in sqlalchemy 1.1.0

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -84,10 +84,12 @@ Host url  'exa+pyodbc://USER:PWD@192.168.14.227..228:1234/my_schema?parameter'
 ========  ====================================================================
 
 *Features*:
+
 - SELECT, INSERT, UPDATE, DELETE statements
 - you can even use the MERGE statement (see unit tests for examples)
 
-*Note*: 
+*Note*:
+
 - Schema name and parameters are optional for the host url string
 - Always use all lower-case identifiers for schema, table and column names. SQLAlchemy treats all lower-case identifiers as case-insensitive, the dialect takes care of transforming the identifier into a case-insensitive representation of the specific database (in case of EXASol this is upper-case as for Oracle)
 - As of EXASol client driver version 4.1.2 you can pass the flag 'INTTYPESINRESULTSIFPOSSIBLE=y' in the connection string (or configure it in your DSN). This will convert DECIMAL data types to Integer-like data types. Creating integers is a factor three faster in Python than creating Decimals.
@@ -98,7 +100,9 @@ Unit tests
 
 To run the unit tests you need:
 
-1. set the `default` connection string in the `setup.cfg` file;
+1. set the `default` connection string in the `setup.cfg` file, which should contain
+   an existing schema to run tests against.  Note that the tests also use a schema
+   "test_schema";
 1. set the `DRIVER` path under the `EXAODBC` section in the
    `odbcconfig/odbcinst.ini` file;
 1. set the `ODBCINSTINI` and `ODBCINST` environment variables to point to the

--- a/sqlalchemy_exasol/requirements.py
+++ b/sqlalchemy_exasol/requirements.py
@@ -152,3 +152,10 @@ class Requirements(SuiteRequirements):
     def independent_connections(self):
         return exclusions.open()
 
+    @property
+    def parens_in_union_contained_select_w_limit_offset(self):
+        return exclusions.closed()
+
+    @property
+    def parens_in_union_contained_select_wo_limit_offset(self):
+        return exclusions.closed()


### PR DESCRIPTION
sqlalchemy 1.1.0 tests more sql constructs than previously. Not all of them are supported by exasol. This commit blacklists these tests.
It also adds some more instructions of how to run tests.